### PR TITLE
Set priority to 1010 so that plugin will be picked up before oAuth plugin

### DIFF
--- a/handler.lua
+++ b/handler.lua
@@ -18,6 +18,6 @@ function CookieToHeaders:access(plugin_conf)
     end
 end
 
-CookieToHeaders.PRIORITY = 1001
+CookieToHeaders.PRIORITY = 1010
 
 return CookieToHeaders


### PR DESCRIPTION
The priority for oAuth plugin in latest kong version (0.14.0) is 1004, which is greater than the current priority (1001) for cookies to header plugin. 

I chose `1010` because this number is not being used in the kong and this number is greater than all security related plugins priorities.